### PR TITLE
Improve the cartodbfy error control

### DIFF
--- a/gdal/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
+++ b/gdal/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
@@ -471,6 +471,12 @@ OGRLayer   *OGRCARTODataSource::ICreateLayer( const char *pszNameIn,
                         "Cannot register table in dashboard with "
                         "cdb_cartodbfytable() since its SRS is not EPSG:4326");
             }
+            else
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                        "Cannot register table in dashboard with "
+                        "cdb_cartodbfytable() since its SRS is not defined");
+            }
             bCartoify = false;
         }
     }


### PR DESCRIPTION
If the source data doesn't have a defined SRS we need to show a warning because the user doesn't know why that dataset is not being cartodbfied